### PR TITLE
set nfs_server to the undercloud-0 ip

### DIFF
--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -35,8 +35,7 @@ backup_excludes:
 nfs_client:
   - controller_nodes
 
-nfs_server:
-  - undercloud
+nfs_server: 192.168.24.1 
 
 
 # Configure which service type structure is deployed on the overcloud nodes.


### PR DESCRIPTION
Configure the nfs_server as an array makes the /etc/rear/local.conf unusable, something like:
OUTPUT_URL=nfs://[u'undercloud-0]]//system_backups

Configure the nfs_server with the undercloud-0 ip avoids the need of adding the
undercloud-0 to the hosts