### PR TITLE
Fixed the "nfs_servers" name remove the last s

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Edit the inventory file: (with your favortie editor)
 [hypervisor_nodes]
 0.0.0.0  ansible_user=root
 
-[nfs_servers]
+[nfs_server]
 0.0.0.0
 ```
 

--- a/inventory
+++ b/inventory
@@ -9,6 +9,6 @@
 #0.0.0.0  ansible_user=root
 #0.0.0.0  ansible_user=root
 
-[nfs_servers]
+[nfs_server]
 #0.0.0.0
 #0.0.0.0


### PR DESCRIPTION
The Readme and the inventory has the name in plural,
but the roles and playbook in singular.
This patch fixed that and set the name in singular in
all the places.